### PR TITLE
k8s-app: 0 out grace period

### DIFF
--- a/k8s-app.yml
+++ b/k8s-app.yml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: node-app
     spec:
+      terminationGracePeriodSeconds: 0
       containers:
       - name: node-app
         image: node-app


### PR DESCRIPTION
the default grace period is 30 seconds which makes for annoying latency
between a code change and a refresh showing something on the page.